### PR TITLE
Typo fix in index.md nmitigarlos -> mitigarlos

### DIFF
--- a/docs/bienvenida/index.md
+++ b/docs/bienvenida/index.md
@@ -34,7 +34,7 @@ Recuerda que esta plataforma es gratuita y usted asume toda la responsabilidad d
 A continuación se presentan algunas de las categorías de audiencia a muy alto nivel y cómo este proyecto les ayuda.
 
 :::info Blue Team
-Comprenda cómo piensan, trabajan y explotan los problemas de seguridad los atacantes, y aplique estos conocimientos para detectarlos y nmitigarlos en el mundo real
+Comprenda cómo piensan, trabajan y explotan los problemas de seguridad los atacantes, y aplique estos conocimientos para detectarlos y mitigarlos en el mundo real
 :::
 
 :::caution Plataforma y DevOps


### PR DESCRIPTION
I've noticed a small typo in the documentation at https://www.acloudsecurity.ninja/docs/. 

There's an extra"n" in "nmitigarlos," which should be "mitigarlos." I've made the necessary correction in this pull request.

This minor change ensures the accuracy of the documentation and improves its readability. 

Please review and consider merging this fix into the main branch.