### PR TITLE
feat(app): login/logout OAuth PKCE contra Cognito real (S1-03)

### DIFF
--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -1,0 +1,29 @@
+# Copia este archivo a .env.local y completa los valores reales.
+# .env.local nunca se commitea (ver .gitignore).
+
+# --- Cognito User Pool (Hosted UI) ---
+# ID del User Pool, ej: us-east-1_qHj16czdO
+COGNITO_USER_POOL_ID=
+
+# App client ID del User Pool Client público (PKCE, sin secret)
+COGNITO_CLIENT_ID=
+
+# Dominio de la Hosted UI, SIN protocolo, ej: cloudsec-ninja-prod.auth.us-east-1.amazoncognito.com
+COGNITO_DOMAIN=
+
+# --- URLs de la app (cambian entre local y Amplify) ---
+# URL completa de callback registrada en el App Client de Cognito.
+# Local: http://localhost:3000/callback
+# Amplify: https://<dominio-amplify>/callback
+APP_CALLBACK_URL=http://localhost:3000/callback
+
+# URL a la que Cognito redirige tras cerrar sesión en la Hosted UI.
+# Debe estar registrada como "Sign out URL" en el App Client.
+# Local: http://localhost:3000/
+# Amplify: https://<dominio-amplify>/
+APP_LOGOUT_URL=http://localhost:3000/
+
+# --- Sesión local ---
+# Secreto simétrico usado para firmar la cookie de sesión (JWT, HS256).
+# Genera uno con: openssl rand -base64 32
+SESSION_SECRET=

--- a/app/README.md
+++ b/app/README.md
@@ -10,24 +10,70 @@ propio `package.json`, su propio `tsconfig.json` y su propio build.
 
 En las próximas historias esta capa se irá construyendo de forma incremental.
 
-## Estado actual (S1-01)
+## Estado actual (S1-03)
 
-Setup inicial para validar el pipeline de deploy a **AWS Amplify Hosting**. Por
-ahora solo existe una página inicial (`app/(public)/page.tsx`) que renderiza un
-título de "en construcción".
+Login/logout funcional contra el Cognito real vía Hosted UI, usando OAuth
+Authorization Code + PKCE. Es solo para **probar que el login funciona**; el
+dashboard real de estudiante es una historia futura.
+
+- **Librerías**: [`openid-client`](https://github.com/panva/openid-client)
+  (descubrimiento OIDC, construcción de la URL de authorize, intercambio de
+  código por tokens) y [`jose`](https://github.com/panva/jose) (firmar/verificar
+  la cookie de sesión).
+- **Sesión**: cookie `cs_session`, httpOnly + Secure (en producción) +
+  SameSite=Lax, con un JWT propio firmado (HS256, `SESSION_SECRET`) que solo
+  contiene `sub` y `email` — nunca los tokens crudos de Cognito. Sin base de
+  datos ni almacén de sesión externo.
+- **PKCE/state**: durante el viaje de ida y vuelta a la Hosted UI, el
+  `code_verifier` y el `state` se guardan en otra cookie httpOnly firmada de
+  corta duración (`cs_oauth_state`, 5 min), que se consume (lee y borra) en
+  `/callback`.
+- **Logout**: borra la cookie de sesión local y además redirige al endpoint
+  `/logout` propio de la Hosted UI de Cognito (no es parte del estándar OIDC;
+  Cognito no implementa RP-Initiated Logout), para cerrar también esa sesión.
+
+### Rutas de autenticación
+
+| Ruta         | Qué hace |
+| ------------ | -------- |
+| `GET /login`     | Genera PKCE + state, guarda la cookie temporal y redirige a la Hosted UI de Cognito. |
+| `GET /callback`  | Recibe el `code`, valida PKCE/state, intercambia el código por tokens y crea la cookie de sesión. |
+| `GET /logout`    | Borra la cookie de sesión y redirige al `/logout` de la Hosted UI. |
+| `GET /dashboard` | Ruta de prueba protegida: muestra "Hola, {email}" si hay sesión válida, si no redirige a `/login`. |
 
 ## Estructura
 
 ```
 app/
-├── app/                     # App Router de Next.js
-│   ├── layout.tsx           # Root layout
-│   └── (public)/
-│       └── page.tsx         # Página inicial (ruta "/")
+├── app/                             # App Router de Next.js
+│   ├── layout.tsx                   # Root layout
+│   ├── (public)/
+│   │   └── page.tsx                 # Página inicial (ruta "/"), botón "Iniciar sesión"
+│   ├── (estudiante)/
+│   │   └── dashboard/
+│   │       └── page.tsx             # Ruta protegida de prueba
+│   ├── login/route.ts               # Redirige a la Hosted UI (PKCE)
+│   ├── callback/route.ts            # Intercambia el code por tokens, crea sesión
+│   └── logout/route.ts              # Cierra sesión local + Hosted UI
+├── lib/auth/
+│   ├── env.ts                       # Lectura/validación de variables de entorno
+│   ├── oidc.ts                      # Config OIDC (discovery) y URL de logout de Cognito
+│   ├── session.ts                   # Cookie de sesión (jose)
+│   └── oauth-state.ts               # Cookie temporal de PKCE/state (jose)
+├── .env.local.example
 ├── next.config.ts
 ├── package.json
 └── tsconfig.json
 ```
+
+## Variables de entorno
+
+Copia `.env.local.example` a `.env.local` y completa los valores (ver ese
+archivo para el detalle de cada variable): `COGNITO_USER_POOL_ID`,
+`COGNITO_CLIENT_ID`, `COGNITO_DOMAIN`, `APP_CALLBACK_URL`, `APP_LOGOUT_URL`,
+`SESSION_SECRET`. `APP_CALLBACK_URL`/`APP_LOGOUT_URL` cambian entre local
+(`localhost:3000`) y Amplify (el dominio real), y deben coincidir con lo
+registrado en el App Client de Cognito.
 
 > Nota: el directorio del router de Next.js se llama `app/` por convención, por
 > eso queda anidado como `app/app/`. La carpeta externa `app/` es la raíz del

--- a/app/app/(estudiante)/dashboard/page.tsx
+++ b/app/app/(estudiante)/dashboard/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+
+// Página de prueba para validar el login (S1-03). El dashboard real es una historia futura.
+export default async function DashboardPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/login");
+  }
+
+  return (
+    <main>
+      <h1>Hola, {session.email}</h1>
+      <a href="/logout">Cerrar sesión</a>
+    </main>
+  );
+}

--- a/app/app/(public)/page.tsx
+++ b/app/app/(public)/page.tsx
@@ -1,3 +1,8 @@
 export default function HomePage() {
-  return <h1>CloudSec Ninja — en construcción</h1>;
+  return (
+    <main>
+      <h1>CloudSec Ninja — en construcción</h1>
+      <a href="/login">Iniciar sesión</a>
+    </main>
+  );
 }

--- a/app/app/callback/route.ts
+++ b/app/app/callback/route.ts
@@ -1,0 +1,36 @@
+import { type NextRequest, NextResponse } from "next/server";
+import * as client from "openid-client";
+import { getOidcConfig } from "@/lib/auth/oidc";
+import { consumeOAuthStateCookie } from "@/lib/auth/oauth-state";
+import { createSessionCookie } from "@/lib/auth/session";
+
+export async function GET(request: NextRequest) {
+  const oauthState = await consumeOAuthStateCookie();
+  if (!oauthState) {
+    // Cookie de estado ausente o expirada (>5 min): no podemos validar PKCE/state con seguridad.
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const config = await getOidcConfig();
+
+  let tokens;
+  try {
+    tokens = await client.authorizationCodeGrant(config, request, {
+      pkceCodeVerifier: oauthState.codeVerifier,
+      expectedState: oauthState.state,
+    });
+  } catch (error) {
+    console.error("Error al intercambiar el código de autorización con Cognito:", error);
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const claims = tokens.claims();
+  if (!claims || typeof claims.email !== "string") {
+    console.error("El id_token de Cognito no incluye el claim 'email'.");
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  await createSessionCookie({ sub: claims.sub, email: claims.email });
+
+  return NextResponse.redirect(new URL("/dashboard", request.url));
+}

--- a/app/app/login/route.ts
+++ b/app/app/login/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import * as client from "openid-client";
+import { authEnv } from "@/lib/auth/env";
+import { getOidcConfig, OAUTH_SCOPE } from "@/lib/auth/oidc";
+import { createOAuthStateCookie } from "@/lib/auth/oauth-state";
+
+export async function GET() {
+  const config = await getOidcConfig();
+
+  // Deben generarse de nuevo en cada redirect a la Hosted UI.
+  const codeVerifier = client.randomPKCECodeVerifier();
+  const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+  const state = client.randomState();
+
+  const authorizationUrl = client.buildAuthorizationUrl(config, {
+    redirect_uri: authEnv.callbackUrl,
+    scope: OAUTH_SCOPE,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    state,
+  });
+
+  await createOAuthStateCookie({ codeVerifier, state });
+
+  return NextResponse.redirect(authorizationUrl);
+}

--- a/app/app/logout/route.ts
+++ b/app/app/logout/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { buildCognitoLogoutUrl } from "@/lib/auth/oidc";
+import { clearSessionCookie } from "@/lib/auth/session";
+
+export async function GET() {
+  await clearSessionCookie();
+  // También cierra la sesión de la Hosted UI (si no, un nuevo /login con Google podría
+  // reautenticar sin pedir credenciales de nuevo).
+  return NextResponse.redirect(buildCognitoLogoutUrl());
+}

--- a/app/lib/auth/env.ts
+++ b/app/lib/auth/env.ts
@@ -1,0 +1,36 @@
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Falta la variable de entorno ${name}. Revisa .env.local (ver .env.local.example).`);
+  }
+  return value;
+}
+
+export const authEnv = {
+  get userPoolId(): string {
+    return required("COGNITO_USER_POOL_ID");
+  },
+  get clientId(): string {
+    return required("COGNITO_CLIENT_ID");
+  },
+  get domain(): string {
+    return required("COGNITO_DOMAIN");
+  },
+  get callbackUrl(): string {
+    return required("APP_CALLBACK_URL");
+  },
+  get logoutUrl(): string {
+    return required("APP_LOGOUT_URL");
+  },
+  get sessionSecret(): string {
+    return required("SESSION_SECRET");
+  },
+  get region(): string {
+    // El user_pool_id de Cognito tiene el formato "{region}_{id}", ej. "us-east-1_qHj16czdO".
+    const region = this.userPoolId.split("_")[0];
+    if (!region) {
+      throw new Error("COGNITO_USER_POOL_ID tiene un formato inválido, se esperaba '{region}_{id}'.");
+    }
+    return region;
+  },
+};

--- a/app/lib/auth/oauth-state.ts
+++ b/app/lib/auth/oauth-state.ts
@@ -1,0 +1,57 @@
+import { SignJWT, jwtVerify } from "jose";
+import { cookies } from "next/headers";
+import { authEnv } from "./env";
+
+const OAUTH_STATE_COOKIE_NAME = "cs_oauth_state";
+// Vida corta: solo necesita sobrevivir el viaje de ida y vuelta a la Hosted UI.
+const OAUTH_STATE_TTL_SECONDS = 60 * 5;
+
+export interface OAuthState {
+  codeVerifier: string;
+  state: string;
+}
+
+function getSecretKey(): Uint8Array {
+  return new TextEncoder().encode(authEnv.sessionSecret);
+}
+
+/**
+ * Guarda code_verifier (PKCE) + state en una cookie httpOnly firmada de corta duración,
+ * para poder validarlos cuando Cognito redirige de vuelta a /callback.
+ */
+export async function createOAuthStateCookie(value: OAuthState): Promise<void> {
+  const token = await new SignJWT({ codeVerifier: value.codeVerifier, state: value.state })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(`${OAUTH_STATE_TTL_SECONDS}s`)
+    .sign(getSecretKey());
+
+  const store = await cookies();
+  store.set(OAUTH_STATE_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: OAUTH_STATE_TTL_SECONDS,
+  });
+}
+
+/** Lee y borra la cookie de estado OAuth (uso único). */
+export async function consumeOAuthStateCookie(): Promise<OAuthState | null> {
+  const store = await cookies();
+  const token = store.get(OAUTH_STATE_COOKIE_NAME)?.value;
+  store.delete(OAUTH_STATE_COOKIE_NAME);
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, getSecretKey());
+    if (typeof payload.codeVerifier !== "string" || typeof payload.state !== "string") {
+      return null;
+    }
+    return { codeVerifier: payload.codeVerifier, state: payload.state };
+  } catch {
+    return null;
+  }
+}

--- a/app/lib/auth/oidc.ts
+++ b/app/lib/auth/oidc.ts
@@ -1,0 +1,39 @@
+import * as client from "openid-client";
+import { authEnv } from "./env";
+
+// Scopes: openid (requerido para id_token) + email (para mostrar "Hola, {email}").
+export const OAUTH_SCOPE = "openid email";
+
+let configPromise: Promise<client.Configuration> | null = null;
+
+/**
+ * El discovery document de Cognito (issuer = cognito-idp.{region}.amazonaws.com/{userPoolId})
+ * expone authorization_endpoint/token_endpoint/userinfo_endpoint apuntando al dominio de la
+ * Hosted UI. Se cachea a nivel de módulo para no repetir la llamada de discovery en cada request.
+ */
+export function getOidcConfig(): Promise<client.Configuration> {
+  if (!configPromise) {
+    const issuer = new URL(
+      `https://cognito-idp.${authEnv.region}.amazonaws.com/${authEnv.userPoolId}`,
+    );
+    configPromise = client
+      .discovery(issuer, authEnv.clientId, undefined, client.None())
+      .catch((error: unknown) => {
+        configPromise = null;
+        throw error;
+      });
+  }
+  return configPromise;
+}
+
+/**
+ * Cognito no implementa RP-Initiated Logout (no publica end_session_endpoint en su discovery
+ * document); el cierre de sesión de la Hosted UI usa un endpoint propio: GET /logout.
+ * https://docs.aws.amazon.com/cognito/latest/developerguide/federation-endpoints.html
+ */
+export function buildCognitoLogoutUrl(): string {
+  const url = new URL(`https://${authEnv.domain}/logout`);
+  url.searchParams.set("client_id", authEnv.clientId);
+  url.searchParams.set("logout_uri", authEnv.logoutUrl);
+  return url.toString();
+}

--- a/app/lib/auth/session.ts
+++ b/app/lib/auth/session.ts
@@ -1,0 +1,60 @@
+import { SignJWT, jwtVerify } from "jose";
+import { cookies } from "next/headers";
+import { authEnv } from "./env";
+
+const SESSION_COOKIE_NAME = "cs_session";
+const SESSION_TTL_SECONDS = 60 * 60 * 8; // 8h
+
+export interface SessionPayload {
+  sub: string;
+  email: string;
+}
+
+function getSecretKey(): Uint8Array {
+  return new TextEncoder().encode(authEnv.sessionSecret);
+}
+
+/**
+ * Guarda la sesión como un JWT propio (firmado, no cifrado) en una cookie httpOnly.
+ * Contiene solo sub/email, nunca los tokens crudos de Cognito.
+ */
+export async function createSessionCookie(payload: SessionPayload): Promise<void> {
+  const token = await new SignJWT({ email: payload.email })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(payload.sub)
+    .setIssuedAt()
+    .setExpirationTime(`${SESSION_TTL_SECONDS}s`)
+    .sign(getSecretKey());
+
+  const store = await cookies();
+  store.set(SESSION_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_TTL_SECONDS,
+  });
+}
+
+export async function getSession(): Promise<SessionPayload | null> {
+  const store = await cookies();
+  const token = store.get(SESSION_COOKIE_NAME)?.value;
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, getSecretKey());
+    if (typeof payload.sub !== "string" || typeof payload.email !== "string") {
+      return null;
+    }
+    return { sub: payload.sub, email: payload.email };
+  } catch {
+    return null;
+  }
+}
+
+export async function clearSessionCookie(): Promise<void> {
+  const store = await cookies();
+  store.delete(SESSION_COOKIE_NAME);
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,9 @@
       "name": "cloudsec-ninja-app",
       "version": "0.0.0",
       "dependencies": {
+        "jose": "^6.2.3",
         "next": "^15.4.5",
+        "openid-client": "^6.8.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -714,6 +716,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -782,6 +793,28 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/picocolors": {

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "jose": "^6.2.3",
     "next": "^15.4.5",
+    "openid-client": "^6.8.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
## Summary
- Login/logout funcional contra el Cognito real (`us-east-1_qHj16czdO`) vía Hosted UI, usando OAuth Authorization Code + PKCE (login nativo + Google, sin formulario custom).
- Sesión propia: cookie `cs_session` httpOnly/Secure(prod)/SameSite=Lax con un JWT firmado (HS256, `SESSION_SECRET`) que solo lleva `sub`/`email` — no se guardan tokens crudos de Cognito.
- Rutas nuevas: `GET /login` (redirige a Hosted UI con PKCE+state), `GET /callback` (intercambia code→tokens, crea sesión), `GET /logout` (borra sesión local + cierra sesión en Hosted UI vía su endpoint `/logout` propio), `GET /dashboard` (ruta protegida de prueba: "Hola, {email}", redirige a `/login` si no hay sesión — no es el dashboard real).
- `app/.env.local.example` con las variables necesarias (sin valores reales).

## Decisiones tomadas (confirmadas con el usuario antes de implementar)
- Librería: `openid-client` (panva, cliente OIDC certificado) + `jose` para firmar la cookie, en vez de Auth.js/NextAuth o Amplify Auth — mantiene el flujo PKCE explícito y auditable, con una huella de dependencias mínima.
- Sesión: JWT propio firmado en cookie httpOnly (no los tokens de Cognito directamente), sin base de datos ni almacén externo.
- El `code_verifier`/`state` de PKCE viajan en una segunda cookie httpOnly firmada de 5 minutos (`cs_oauth_state`), consumida una sola vez en `/callback`.
- Cognito no implementa RP-Initiated Logout (no publica `end_session_endpoint`); el logout usa el endpoint propietario `/logout` de la Hosted UI.

## Fuera de alcance (no tocado)
- `docs/`, `code/`, configuración de Docusaurus/Vercel.
- El dashboard real de estudiante (historia futura).
- Configuración de ESLint (`next lint` pide configurarlo interactivamente; no existía antes de esta rama tampoco — S1-01 nunca lo configuró).

## Test plan
- [x] `npm run build` pasa limpio (incluye type-check de TypeScript) con env vars dummy.
- [ ] Prueba manual del login real contra Cognito en el navegador (ver instrucciones en la descripción del hand-off / comentario del PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)