### PR TITLE
S2-03: Vista de lección AWS Identity Center con botón real de progreso

### DIFF
--- a/app/app/(estudiante)/dashboard/components/module-row.tsx
+++ b/app/app/(estudiante)/dashboard/components/module-row.tsx
@@ -28,6 +28,11 @@ function metaText(module: ModuleView): string {
   return `${module.completedLessons} de ${module.totalLessons} lecciones`;
 }
 
+// Único módulo con una lección real construida en la app (S2-03) — el
+// resto sigue enlazando al sitio de docs hasta que tengan su propia página.
+const MODULE_ID_WITH_LESSON_PAGE = "gestion-de-identidad-y-accesos";
+const LESSON_PAGE_HREF = "/lecciones/identity-center";
+
 function ModuleAction({ module }: { module: ModuleView }) {
   if (module.status === "completed") {
     return <span className="text-xs font-semibold text-accent-dark">Completado</span>;
@@ -35,9 +40,10 @@ function ModuleAction({ module }: { module: ModuleView }) {
   if (module.status === "locked") {
     return <span className="text-xs text-ink-3">Bloqueado</span>;
   }
+  const href = module.id === MODULE_ID_WITH_LESSON_PAGE ? LESSON_PAGE_HREF : moduleDocsUrl(module);
   return (
     <a
-      href={moduleDocsUrl(module)}
+      href={href}
       className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-[#04231a] transition-colors hover:bg-accent-hover"
     >
       {module.completedLessons === 0 ? "Empezar" : "Continuar"}

--- a/app/app/(estudiante)/lecciones/identity-center/components/code-block.tsx
+++ b/app/app/(estudiante)/lecciones/identity-center/components/code-block.tsx
@@ -1,0 +1,19 @@
+import { codeToHtml } from "shiki";
+
+export async function CodeBlock({ code, lang, filename }: { code: string; lang: string; filename?: string }) {
+  const html = await codeToHtml(code, { lang, theme: "github-dark" });
+
+  return (
+    <div className="mb-5 overflow-hidden rounded-xl border border-border">
+      {filename ? (
+        <div className="border-b border-white/10 bg-ink px-4 py-2 font-mono text-[11px] text-white/60">
+          {filename}
+        </div>
+      ) : null}
+      <div
+        className="overflow-x-auto [&_pre]:p-5 [&_pre]:font-mono [&_pre]:text-[12.5px] [&_pre]:leading-[1.7]"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  );
+}

--- a/app/app/(estudiante)/lecciones/identity-center/components/complete-lesson-button.tsx
+++ b/app/app/(estudiante)/lecciones/identity-center/components/complete-lesson-button.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { CheckIcon } from "./icons";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+export function CompleteLessonButton({ moduleId, lessonId }: { moduleId: string; lessonId: string }) {
+  const router = useRouter();
+  const [status, setStatus] = useState<Status>("idle");
+
+  async function handleClick() {
+    setStatus("loading");
+    try {
+      const response = await fetch("/api/progress", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ module_id: moduleId, lesson_id: lessonId }),
+      });
+
+      if (!response.ok) {
+        setStatus("error");
+        return;
+      }
+
+      setStatus("success");
+      setTimeout(() => router.push("/dashboard"), 900);
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className="flex items-center gap-2 rounded-lg bg-accent-soft px-5 py-3 text-sm font-semibold text-accent-dark">
+        <CheckIcon className="h-4 w-4" />
+        Progreso guardado — volviendo a tu dashboard...
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        onClick={handleClick}
+        disabled={status === "loading"}
+        className="w-fit rounded-lg bg-accent px-5 py-3 text-sm font-semibold text-[#04231a] transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {status === "loading" ? "Guardando..." : "Completar lección"}
+      </button>
+      {status === "error" ? (
+        <p className="text-sm text-red-600">
+          No se pudo guardar tu progreso. Intenta de nuevo — si el problema persiste, cierra sesión y vuelve a entrar.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/app/app/(estudiante)/lecciones/identity-center/components/icons.tsx
+++ b/app/app/(estudiante)/lecciones/identity-center/components/icons.tsx
@@ -1,0 +1,32 @@
+export function DownloadIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M12 15V3M7 10l5 5 5-5M5 21h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function InfoIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+      <path d="M12 16v-4M12 8h.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function PlayIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M8 5v14l11-7z" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M5 13l4 4L19 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/app/app/(estudiante)/lecciones/identity-center/page.tsx
+++ b/app/app/(estudiante)/lecciones/identity-center/page.tsx
@@ -1,0 +1,298 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { CURRICULUM } from "@/lib/progress/curriculum";
+import { CodeBlock } from "./components/code-block";
+import { CompleteLessonButton } from "./components/complete-lesson-button";
+import { DownloadIcon, InfoIcon, PlayIcon } from "./components/icons";
+
+const MODULE_ID = "gestion-de-identidad-y-accesos";
+const LESSON_ID = "aws-identity-center";
+
+const TRUST_POLICY_JSON = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::123456789012:saml-provider/AWSSSO_..."
+      },
+      "Action": ["sts:AssumeRoleWithSAML", "sts:TagSession"],
+      "Condition": {
+        "StringEquals": { "SAML:aud": "https://signin.aws.amazon.com/saml" }
+      }
+    }
+  ]
+}`;
+
+const SCP_JSON = `{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "DenyUnapprovedRegions",
+    "Effect": "Deny",
+    "Action": "*",
+    "Resource": "*",
+    "Condition": {
+      "StringNotEquals": {
+        "aws:RequestedRegion": ["us-east-1", "us-west-2"]
+      }
+    }
+  }]
+}`;
+
+const STS_COMMAND = `$ aws sts get-caller-identity
+
+{
+    "UserId": "AROAEXAMPLE:jgarcia",
+    "Account": "123456789012",
+    "Arn": "arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_ReadOnlyAccess_a1b2c3/jgarcia"
+}`;
+
+export default async function IdentityCenterLessonPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/login");
+  }
+
+  const module = CURRICULUM.find((m) => m.id === MODULE_ID)!;
+  const lesson = module.lessons.find((l) => l.id === LESSON_ID)!;
+
+  return (
+    <main className="min-h-screen bg-bg">
+      <div className="mx-auto max-w-[820px] px-8 py-10">
+        <Link href="/dashboard" className="text-xs font-medium text-ink-3 hover:text-ink-2">
+          ← Volver al dashboard
+        </Link>
+
+        <p className="mt-5 text-xs text-ink-3">
+          {module.title} / {lesson.title}
+        </p>
+        <h1 className="mt-1 font-display text-2xl font-semibold text-ink">
+          AWS Identity Center: acceso centralizado multi-cuenta
+        </h1>
+
+        <div className="mt-3 mb-6 flex gap-1.5">
+          <span className="rounded-md bg-accent-soft px-2.5 py-1 text-[11px] font-semibold text-accent-dark">
+            nivel 200
+          </span>
+          <span className="rounded-md bg-surface-2 px-2.5 py-1 text-[11px] text-ink-2">identity-center</span>
+          <span className="rounded-md bg-surface-2 px-2.5 py-1 text-[11px] text-ink-2">sso</span>
+        </div>
+
+        <div className="relative mb-6 flex aspect-video items-center justify-center overflow-hidden rounded-xl bg-black">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/15">
+            <PlayIcon className="h-6 w-6 text-white" />
+          </div>
+          <div className="absolute bottom-3 left-3.5 text-xs text-white/85">
+            Clase en vivo · AWS Identity Center paso a paso · 41:07
+          </div>
+        </div>
+
+        <h2 className="mb-2.5 font-display text-lg font-semibold text-ink">¿Qué problema resuelve?</h2>
+        <p className="mb-4 text-[14.5px] leading-relaxed text-ink-2">
+          Cuando una organización maneja <strong>más de una cuenta de AWS</strong>, administrar accesos usuario por
+          usuario en cada cuenta se vuelve inmanejable. <code>AWS Identity Center</code> (antes conocido como{" "}
+          <code>AWS SSO</code>) centraliza esto: un solo punto de federación, y desde ahí defines qué usuarios acceden
+          a qué cuentas, con qué nivel de permiso.
+        </p>
+        <p className="mb-5 text-[14.5px] leading-relaxed text-ink-2">
+          A diferencia de IAM tradicional, Identity Center <em>no crea usuarios ni contraseñas nuevas</em> — se
+          conecta a tu proveedor de identidad existente (Okta, Microsoft Entra ID, Active Directory) o usa su propio
+          directorio interno, y desde ahí sincroniza usuarios y grupos.
+        </p>
+
+        <div className="mb-1.5 overflow-hidden rounded-xl border border-border">
+          <div className="flex items-center gap-1.5 bg-[#1a1a1a] px-3.5 py-2">
+            <div className="h-2.5 w-2.5 rounded-full bg-[#EE6A5F]" />
+            <div className="h-2.5 w-2.5 rounded-full bg-[#F5BD4F]" />
+            <div className="h-2.5 w-2.5 rounded-full bg-[#61C454]" />
+            <span className="ml-1.5 text-[11px] text-[#8a8a8a]">consola AWS — IAM Identity Center</span>
+          </div>
+          <svg viewBox="0 0 700 280" className="block w-full bg-[#f4f6f5]">
+            <rect x="0" y="0" width="700" height="44" fill="#232f3e" />
+            <text x="16" y="27" fontFamily="Inter, sans-serif" fontSize="13" fill="#fff" fontWeight="600">
+              AWS IAM Identity Center
+            </text>
+            <text x="600" y="27" fontFamily="Inter, sans-serif" fontSize="11" fill="#9fb3c8">
+              us-east-1
+            </text>
+            <rect x="20" y="64" width="200" height="196" fill="#fff" stroke="#d5dbdb" />
+            <text x="34" y="90" fontFamily="Inter, sans-serif" fontSize="12" fill="#16191f" fontWeight="600">
+              Usuarios
+            </text>
+            <text x="34" y="114" fontFamily="Inter, sans-serif" fontSize="12" fill="#0972d3">
+              Grupos
+            </text>
+            <text x="34" y="138" fontFamily="Inter, sans-serif" fontSize="12" fill="#0972d3">
+              Cuentas de AWS
+            </text>
+            <text x="34" y="162" fontFamily="Inter, sans-serif" fontSize="12" fill="#0972d3">
+              Conjuntos de permisos
+            </text>
+            <text x="34" y="186" fontFamily="Inter, sans-serif" fontSize="12" fill="#0972d3">
+              Aplicaciones
+            </text>
+            <rect x="240" y="64" width="440" height="196" fill="#fff" stroke="#d5dbdb" />
+            <text x="256" y="90" fontFamily="Inter, sans-serif" fontSize="13" fill="#16191f" fontWeight="600">
+              Conjuntos de permisos
+            </text>
+            <rect x="256" y="104" width="408" height="28" fill="#f2f8fd" />
+            <text x="264" y="122" fontFamily="Inter, sans-serif" fontSize="11" fill="#16191f">
+              AdministratorAccess
+            </text>
+            <text x="560" y="122" fontFamily="Inter, sans-serif" fontSize="10" fill="#5f6b7a">
+              PT1H
+            </text>
+            <rect x="256" y="134" width="408" height="28" fill="#fff" />
+            <text x="264" y="152" fontFamily="Inter, sans-serif" fontSize="11" fill="#16191f">
+              ReadOnlyAccess
+            </text>
+            <text x="560" y="152" fontFamily="Inter, sans-serif" fontSize="10" fill="#5f6b7a">
+              PT4H
+            </text>
+            <rect x="256" y="164" width="408" height="28" fill="#f2f8fd" />
+            <text x="264" y="182" fontFamily="Inter, sans-serif" fontSize="11" fill="#16191f">
+              SecurityAudit
+            </text>
+            <text x="560" y="182" fontFamily="Inter, sans-serif" fontSize="10" fill="#5f6b7a">
+              PT2H
+            </text>
+          </svg>
+        </div>
+        <p className="mb-6 text-center text-[11.5px] text-ink-3">
+          Captura: panel de conjuntos de permisos en IAM Identity Center
+        </p>
+
+        <h2 className="mb-2.5 font-display text-lg font-semibold text-ink">Permission sets, la pieza central</h2>
+        <p className="mb-3.5 text-[14.5px] leading-relaxed text-ink-2">
+          Un <strong>permission set</strong> es una plantilla reutilizable de permisos. Internamente, Identity Center
+          crea un <code>IAM Role</code> por cada combinación de permission set + cuenta asignada — tú no gestionas
+          esos roles a mano.
+        </p>
+
+        <table className="mb-5 w-full border-collapse text-[13px]">
+          <thead>
+            <tr>
+              <th className="border border-border bg-surface-2 px-3 py-2 text-left">Permission set</th>
+              <th className="border border-border bg-surface-2 px-3 py-2 text-left">Duración de sesión</th>
+              <th className="border border-border bg-surface-2 px-3 py-2 text-left">Uso típico</th>
+            </tr>
+          </thead>
+          <tbody className="text-ink-2">
+            <tr>
+              <td className="border border-border px-3 py-2">
+                <code>AdministratorAccess</code>
+              </td>
+              <td className="border border-border px-3 py-2">1 hora</td>
+              <td className="border border-border px-3 py-2">Break-glass, uso puntual</td>
+            </tr>
+            <tr>
+              <td className="border border-border px-3 py-2">
+                <code>ReadOnlyAccess</code>
+              </td>
+              <td className="border border-border px-3 py-2">4 horas</td>
+              <td className="border border-border px-3 py-2">Auditoría, soporte</td>
+            </tr>
+            <tr>
+              <td className="border border-border px-3 py-2">
+                <code>SecurityAudit</code>
+              </td>
+              <td className="border border-border px-3 py-2">2 horas</td>
+              <td className="border border-border px-3 py-2">Equipo de seguridad</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p className="mb-2 text-[14px] leading-relaxed text-ink-2">
+          Cosas que <strong>debes recordar</strong> sobre permission sets:
+        </p>
+        <ul className="mb-5 list-disc space-y-1 pl-5 text-[14px] leading-relaxed text-ink-2">
+          <li>Un permission set define <em>qué</em> puede hacer un usuario, no <em>quién</em> es</li>
+          <li>
+            La duración de sesión (<code>SessionDuration</code>) limita cuánto dura la credencial temporal antes de
+            expirar
+          </li>
+          <li>
+            Identity Center <strong>no modifica</strong> tus IAM users o roles existentes — convive con ellos
+          </li>
+        </ul>
+
+        <h2 className="mb-2.5 font-display text-lg font-semibold text-ink">El rol que se crea por detrás</h2>
+        <p className="mb-3.5 text-[14.5px] leading-relaxed text-ink-2">
+          Cuando asignas un permission set a un usuario sobre una cuenta, Identity Center provisiona un{" "}
+          <code>IAM Role</code> con un nombre reservado (<code>AWSReservedSSO_*</code>). Su trust policy confía en el
+          proveedor SAML interno de Identity Center — nunca directamente en el usuario final:
+        </p>
+
+        <CodeBlock code={TRUST_POLICY_JSON} lang="json" />
+
+        <p className="mb-3.5 text-[14.5px] leading-relaxed text-ink-2">
+          Nota el uso de <code>sts:TagSession</code> — esto permite que el rol asumido lleve atributos del usuario
+          (como su departamento o equipo), habilitando <strong>ABAC</strong> incluso dentro de sesiones federadas.
+        </p>
+
+        <div className="mb-4 flex items-center justify-between rounded-xl border border-border bg-surface-2 px-4.5 py-3.5">
+          <div className="flex items-center gap-2.5">
+            <DownloadIcon className="h-4.5 w-4.5 text-accent-dark" />
+            <span className="text-[13px]">identity-center-permission-sets.tf</span>
+          </div>
+          <button
+            type="button"
+            disabled
+            title="Generación real de archivos: historia futura"
+            className="cursor-not-allowed rounded-lg border border-border px-3.5 py-1.5 text-xs font-medium text-ink-3"
+          >
+            Descargar Terraform
+          </button>
+        </div>
+        <div className="mb-6 flex items-center justify-between rounded-xl border border-border bg-surface-2 px-4.5 py-3.5">
+          <div className="flex items-center gap-2.5">
+            <DownloadIcon className="h-4.5 w-4.5 text-accent-dark" />
+            <span className="text-[13px]">identity-center-scp-baseline.yaml</span>
+          </div>
+          <button
+            type="button"
+            disabled
+            title="Generación real de archivos: historia futura"
+            className="cursor-not-allowed rounded-lg border border-border px-3.5 py-1.5 text-xs font-medium text-ink-3"
+          >
+            Descargar CloudFormation
+          </button>
+        </div>
+
+        <h2 className="mb-2.5 font-display text-lg font-semibold text-ink">
+          Reforzando con Service Control Policies
+        </h2>
+        <p className="mb-3.5 text-[14.5px] leading-relaxed text-ink-2">
+          Un permission set mal configurado no es el fin del mundo si tienes <strong>SCPs</strong> (Service Control
+          Policies) a nivel de organización — estas actúan como un techo que <em>ni siquiera un administrador</em>{" "}
+          puede traspasar, sin importar qué permission set tenga asignado:
+        </p>
+
+        <CodeBlock code={SCP_JSON} lang="json" />
+
+        <div className="mb-6 flex items-center gap-2.5 rounded-xl bg-accent-soft px-4 py-3">
+          <InfoIcon className="h-4.5 w-4.5 shrink-0 text-accent-dark" />
+          <span className="text-[13px] text-accent-dark">
+            <strong>Dato clave:</strong> las SCPs restringen, nunca otorgan permisos. Un permission set con{" "}
+            <code>AdministratorAccess</code> sigue bloqueado si la SCP lo deniega explícitamente.
+          </span>
+        </div>
+
+        <h2 className="mb-2.5 font-display text-lg font-semibold text-ink">Ejercicio práctico</h2>
+        <p className="mb-3.5 text-[14.5px] leading-relaxed text-ink-2">
+          Verifica desde tu terminal qué identidad federada estás usando en este momento:
+        </p>
+
+        <CodeBlock code={STS_COMMAND} lang="bash" />
+
+        <p className="mb-8 text-[14.5px] leading-relaxed text-ink-2">
+          Observa el <code>Arn</code>: confirma que estás operando bajo un rol de Identity Center (
+          <code>AWSReservedSSO_*</code>), no con credenciales de un <code>IAM User</code> tradicional.
+        </p>
+
+        <CompleteLessonButton moduleId={MODULE_ID} lessonId={LESSON_ID} />
+      </div>
+    </main>
+  );
+}

--- a/app/app/api/progress/route.ts
+++ b/app/app/api/progress/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { markLessonComplete } from "@/lib/progress/api";
+
+/**
+ * Proxy delgado hacia POST /progress (cloudsec-ninja-infra): existe porque
+ * el access_token de Cognito solo se puede obtener leyendo la cookie
+ * httpOnly cs_cognito_rt, y eso solo es posible en un contexto de servidor
+ * (no en el componente cliente que dispara el botón "Completar lección").
+ */
+export async function POST(request: Request) {
+  let body: { module_id?: unknown; lesson_id?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (typeof body.module_id !== "string" || typeof body.lesson_id !== "string") {
+    return NextResponse.json({ error: "missing_ids" }, { status: 400 });
+  }
+
+  const result = await markLessonComplete(body.module_id, body.lesson_id);
+  if (!result.ok) {
+    const status = result.reason === "unauthenticated" ? 401 : 502;
+    return NextResponse.json({ error: result.reason }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/lib/progress/api.ts
+++ b/app/lib/progress/api.ts
@@ -49,3 +49,41 @@ export async function fetchProgress(): Promise<ProgressResult> {
   const data = (await response.json()) as { progress: ProgressItem[] };
   return { ok: true, items: data.progress };
 }
+
+export type MarkLessonCompleteResult = { ok: true } | { ok: false; reason: "unauthenticated" | "api_error" };
+
+/**
+ * Llama a POST /progress (cloudsec-ninja-infra) para marcar una lección
+ * como completada. El endpoint solo acepta {module_id, lesson_id} — no es
+ * un update genérico de status, siempre marca "completed" y calcula los
+ * timestamps del lado del servidor.
+ */
+export async function markLessonComplete(moduleId: string, lessonId: string): Promise<MarkLessonCompleteResult> {
+  const accessToken = await getFreshCognitoAccessToken();
+  if (!accessToken) {
+    return { ok: false, reason: "unauthenticated" };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${authEnv.progressApiUrl}/progress`, {
+      method: "POST",
+      headers: { Authorization: accessToken, "Content-Type": "application/json" },
+      body: JSON.stringify({ module_id: moduleId, lesson_id: lessonId }),
+      cache: "no-store",
+    });
+  } catch (error) {
+    console.error("Error de red al llamar a POST /progress:", error);
+    return { ok: false, reason: "api_error" };
+  }
+
+  if (response.status === 401) {
+    return { ok: false, reason: "unauthenticated" };
+  }
+  if (!response.ok) {
+    console.error(`POST /progress devolvió ${response.status}`);
+    return { ok: false, reason: "api_error" };
+  }
+
+  return { ok: true };
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,7 +12,8 @@
         "next": "^15.4.5",
         "openid-client": "^6.8.4",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "shiki": "^4.3.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.2",
@@ -700,6 +701,106 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
+      "integrity": "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.3.1",
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.1.tgz",
+      "integrity": "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.1.tgz",
+      "integrity": "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
+      "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz",
+      "integrity": "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
+      "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -980,6 +1081,24 @@
         "tailwindcss": "4.3.2"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
@@ -1010,6 +1129,18 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "license": "ISC"
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001800",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
@@ -1030,11 +1161,51 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1042,6 +1213,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1051,6 +1231,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -1073,6 +1266,52 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -1364,6 +1603,116 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -1471,6 +1820,23 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/openid-client": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
@@ -1519,6 +1885,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -1539,6 +1915,30 @@
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -1604,6 +2004,25 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.1.tgz",
+      "integrity": "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.3.1",
+        "@shikijs/engine-javascript": "4.3.1",
+        "@shikijs/engine-oniguruma": "4.3.1",
+        "@shikijs/langs": "4.3.1",
+        "@shikijs/themes": "4.3.1",
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1611,6 +2030,30 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/styled-jsx": {
@@ -1657,6 +2100,16 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1683,6 +2136,112 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,8 @@
     "next": "^15.4.5",
     "openid-client": "^6.8.4",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "shiki": "^4.3.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.2",
@@ -25,6 +26,6 @@
     "typescript": "^5.7.0"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
## Resumen

- Primera página de lección real de la app: `/lecciones/identity-center`, contenido de referencia tomado de `design-reference/mockup.html` (mismo texto/estructura, componentes Tailwind reales, no HTML copiado).
- `module_id`/`lesson_id` (`gestion-de-identidad-y-accesos` / `aws-identity-center`) tomados de `sidebars.js` vía `curriculum.ts` — ya documentados ahí, no se inventaron IDs nuevos.
- Botón "Completar lección" llama `POST /progress` reusando el mecanismo de refresh_token/access_token de S2-02, vía un nuevo route handler `app/api/progress` (proxy necesario porque el access_token solo se puede leer server-side, de la cookie httpOnly `cs_cognito_rt`).
- Body del POST confirmado con el usuario en conversación: `{module_id, lesson_id}` — el endpoint siempre marca `"completed"` y calcula timestamps server-side.
- `ModuleRow` enlaza la card de "Gestión de Identidad y Accesos" a la nueva página interna; el resto de módulos sigue enlazando al sitio de docs (no tienen página propia todavía).
- Syntax highlighting con `shiki` (decisión consultada con el usuario), resuelto 100% server-side, sin JS extra al cliente.

## Fuera de alcance (según la historia)

Contenido dinámico desde GitHub, más de una lección, videos reales, descargas reales de Terraform/CloudFormation, asistente de estudio, comentarios.

## Nota de infra

`shiki` requiere Node >=20 en sus subpaquetes — se actualizó `engines.node` en `app/package.json` de `>=18.18.0` a `>=20` para reflejarlo. **Pendiente confirmar** que el build image de Amplify Hosting (configurado en la consola, fuera de este repo) usa Node >=20; si usa una imagen más vieja, el build de Amplify podría fallar aunque localmente (Node 22) todo pasó verde.

## Test plan

- [x] `tsc --noEmit` sin errores
- [x] `next build` verde (incluye lint embebido)
- [x] Smoke test local: `/lecciones/identity-center` sin sesión redirige a `/login` (igual que `/dashboard`)
- [x] Smoke test local: con una `cs_session` de prueba (JWT propio, sin tocar Cognito real) la página responde 200 y renderiza título, tabla, callout SCP, y 3 bloques de código con highlighting real
- [ ] Prueba manual en navegador con usuario real — ver hand-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)