### PR TITLE
S2-04b: Panel de admin para crear currículum con preview markdown

### DIFF
--- a/app/app/(admin)/panel/components/admin-panel.tsx
+++ b/app/app/(admin)/panel/components/admin-panel.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import type { AdminCurriculumLesson, AdminCurriculumModule } from "@/lib/curriculum/api";
+import { CreateModuleForm } from "./create-module-form";
+import { CurriculumAccordion } from "./curriculum-accordion";
+
+export function AdminPanel({ initialModules }: { initialModules: AdminCurriculumModule[] }) {
+  const [modules, setModules] = useState(initialModules);
+
+  function handleModuleCreated(module: AdminCurriculumModule) {
+    setModules((current) => [...current, module]);
+  }
+
+  function handleLessonCreated(moduleId: string, lesson: AdminCurriculumLesson) {
+    setModules((current) =>
+      current.map((module) => (module.module_id === moduleId ? { ...module, lessons: [...module.lessons, lesson] } : module)),
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <CreateModuleForm onCreated={handleModuleCreated} />
+      <CurriculumAccordion modules={modules} onLessonCreated={handleLessonCreated} />
+    </div>
+  );
+}

--- a/app/app/(admin)/panel/components/create-lesson-form.tsx
+++ b/app/app/(admin)/panel/components/create-lesson-form.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import type { AdminCurriculumLesson } from "@/lib/curriculum/api";
+import { MarkdownEditor } from "./markdown-editor";
+import { CheckIcon } from "./icons";
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(new RegExp("[̀-ͯ]", "g"), "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function CreateLessonForm({
+  moduleId,
+  onCreated,
+  onCancel,
+}: {
+  moduleId: string;
+  onCreated: (lesson: AdminCurriculumLesson) => void;
+  onCancel: () => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [lessonId, setLessonId] = useState("");
+  const [lessonIdTouched, setLessonIdTouched] = useState(false);
+  const [order, setOrder] = useState("");
+  const [tagsInput, setTagsInput] = useState("");
+  const [content, setContent] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!title.trim() || !lessonId.trim() || !content.trim()) {
+      return;
+    }
+
+    const tags = tagsInput
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+
+    setStatus("loading");
+    setErrorMessage("");
+    try {
+      const response = await fetch("/api/admin/curriculum/lessons", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          module_id: moduleId,
+          lesson_id: lessonId.trim(),
+          title: title.trim(),
+          order: order ? Number(order) : undefined,
+          content_markdown: content,
+          tags,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setStatus("error");
+        setErrorMessage(data.error === "forbidden" ? "Tu usuario no tiene rol admin." : "No se pudo crear la lección.");
+        return;
+      }
+
+      onCreated({ lesson_id: lessonId.trim(), title: title.trim(), order: order ? Number(order) : undefined, tags });
+
+      setStatus("success");
+      setTitle("");
+      setLessonId("");
+      setLessonIdTouched(false);
+      setOrder("");
+      setTagsInput("");
+      setContent("");
+      setTimeout(() => setStatus("idle"), 2500);
+    } catch {
+      setStatus("error");
+      setErrorMessage("Error de red al crear la lección.");
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-3 rounded-xl border border-accent bg-surface p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h4 className="font-display text-sm font-semibold text-ink">Crear lección en este módulo</h4>
+        <button type="button" onClick={onCancel} className="text-xs font-medium text-ink-3 hover:text-ink-2">
+          Cancelar
+        </button>
+      </div>
+
+      <div className="mb-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1 text-xs font-medium text-ink-2 sm:col-span-2">
+          Título
+          <input
+            required
+            value={title}
+            onChange={(event) => {
+              setTitle(event.target.value);
+              if (!lessonIdTouched) {
+                setLessonId(slugify(event.target.value));
+              }
+            }}
+            className="rounded-lg border border-border px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+            placeholder="Ej. AWS Identity Center"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-medium text-ink-2">
+          lesson_id (slug)
+          <input
+            required
+            value={lessonId}
+            onChange={(event) => {
+              setLessonIdTouched(true);
+              setLessonId(event.target.value);
+            }}
+            className="rounded-lg border border-border px-3 py-2 font-mono text-sm text-ink outline-none focus:border-accent"
+            placeholder="aws-identity-center"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-medium text-ink-2">
+          Orden
+          <input
+            type="number"
+            value={order}
+            onChange={(event) => setOrder(event.target.value)}
+            className="rounded-lg border border-border px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+            placeholder="1"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-medium text-ink-2 sm:col-span-2">
+          Tags (separados por coma)
+          <input
+            value={tagsInput}
+            onChange={(event) => setTagsInput(event.target.value)}
+            className="rounded-lg border border-border px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+            placeholder="identity-center, sso"
+          />
+        </label>
+      </div>
+
+      <MarkdownEditor value={content} onChange={setContent} />
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={status === "loading"}
+          className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-[#04231a] transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status === "loading" ? "Creando..." : "Crear lección"}
+        </button>
+        {status === "success" ? (
+          <span className="flex items-center gap-1.5 text-sm font-medium text-accent-dark">
+            <CheckIcon className="h-4 w-4" />
+            Lección creada
+          </span>
+        ) : null}
+        {status === "error" ? <span className="text-sm text-red-600">{errorMessage}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/app/app/(admin)/panel/components/create-module-form.tsx
+++ b/app/app/(admin)/panel/components/create-module-form.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import type { AdminCurriculumModule } from "@/lib/curriculum/api";
+import { CheckIcon } from "./icons";
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(new RegExp("[̀-ͯ]", "g"), "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function CreateModuleForm({ onCreated }: { onCreated: (module: AdminCurriculumModule) => void }) {
+  const [title, setTitle] = useState("");
+  const [moduleId, setModuleId] = useState("");
+  const [moduleIdTouched, setModuleIdTouched] = useState(false);
+  const [order, setOrder] = useState("");
+  const [level, setLevel] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!title.trim() || !moduleId.trim()) {
+      return;
+    }
+
+    setStatus("loading");
+    setErrorMessage("");
+    try {
+      const response = await fetch("/api/admin/curriculum/modules", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          module_id: moduleId.trim(),
+          title: title.trim(),
+          order: order ? Number(order) : undefined,
+          level: level ? Number(level) : undefined,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setStatus("error");
+        setErrorMessage(data.error === "forbidden" ? "Tu usuario no tiene rol admin." : "No se pudo crear el módulo.");
+        return;
+      }
+
+      onCreated({
+        module_id: moduleId.trim(),
+        title: title.trim(),
+        order: order ? Number(order) : undefined,
+        level: level ? Number(level) : undefined,
+        lessons: [],
+      });
+
+      setStatus("success");
+      setTitle("");
+      setModuleId("");
+      setModuleIdTouched(false);
+      setOrder("");
+      setLevel("");
+      setTimeout(() => setStatus("idle"), 2500);
+    } catch {
+      setStatus("error");
+      setErrorMessage("Error de red al crear el módulo.");
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-xl border border-border bg-surface p-5">
+      <h3 className="mb-4 font-display text-base font-semibold text-ink">Crear módulo</h3>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1 text-xs font-medium text-ink-2 sm:col-span-2">
+          Título
+          <input
+            required
+            value={title}
+            onChange={(event) => {
+              setTitle(event.target.value);
+              if (!moduleIdTouched) {
+                setModuleId(slugify(event.target.value));
+              }
+            }}
+            className="rounded-lg border border-border px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+            placeholder="Ej. Gestión de Identidad y Accesos"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-medium text-ink-2 sm:col-span-2">
+          module_id (slug)
+          <input
+            required
+            value={moduleId}
+            onChange={(event) => {
+              setModuleIdTouched(true);
+              setModuleId(event.target.value);
+            }}
+            className="rounded-lg border border-border px-3 py-2 font-mono text-sm text-ink outline-none focus:border-accent"
+            placeholder="ej-gestion-de-identidad"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-medium text-ink-2">
+          Orden
+          <input
+            type="number"
+            value={order}
+            onChange={(event) => setOrder(event.target.value)}
+            className="rounded-lg border border-border px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+            placeholder="1"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-medium text-ink-2">
+          Nivel
+          <input
+            type="number"
+            value={level}
+            onChange={(event) => setLevel(event.target.value)}
+            className="rounded-lg border border-border px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+            placeholder="100"
+          />
+        </label>
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={status === "loading"}
+          className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-[#04231a] transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status === "loading" ? "Creando..." : "Crear módulo"}
+        </button>
+        {status === "success" ? (
+          <span className="flex items-center gap-1.5 text-sm font-medium text-accent-dark">
+            <CheckIcon className="h-4 w-4" />
+            Módulo creado
+          </span>
+        ) : null}
+        {status === "error" ? <span className="text-sm text-red-600">{errorMessage}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/app/app/(admin)/panel/components/curriculum-accordion.tsx
+++ b/app/app/(admin)/panel/components/curriculum-accordion.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import type { AdminCurriculumLesson, AdminCurriculumModule } from "@/lib/curriculum/api";
+import { CreateLessonForm } from "./create-lesson-form";
+import { ChevronIcon, PlusIcon } from "./icons";
+
+function ModuleCard({
+  module,
+  onLessonCreated,
+}: {
+  module: AdminCurriculumModule;
+  onLessonCreated: (moduleId: string, lesson: AdminCurriculumLesson) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [addingLesson, setAddingLesson] = useState(false);
+
+  return (
+    <div className={`rounded-xl border bg-surface transition-colors ${open ? "border-accent" : "border-border"}`}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left"
+      >
+        <div>
+          <p className="text-sm font-semibold text-ink">
+            {module.order ?? "·"}. {module.title}
+          </p>
+          <p className="mt-0.5 text-[12px] text-ink-3">
+            {module.lessons.length} lecciones{module.level ? ` · nivel ${module.level}` : ""} ·{" "}
+            <span className="font-mono">{module.module_id}</span>
+          </p>
+        </div>
+        <ChevronIcon className={`h-4.5 w-4.5 shrink-0 text-ink-3 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open ? (
+        <div className="border-t border-border px-5 pb-5 pt-3">
+          {module.lessons.length > 0 ? (
+            <ul className="mb-3 space-y-1.5">
+              {module.lessons.map((lesson) => (
+                <li key={lesson.lesson_id} className="flex items-center gap-2 py-1 text-[13.5px] text-ink-2">
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
+                  {lesson.title}
+                  <span className="font-mono text-[11px] text-ink-3">({lesson.lesson_id})</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mb-3 text-[13px] text-ink-3 italic">Este módulo todavía no tiene lecciones.</p>
+          )}
+
+          {addingLesson ? (
+            <CreateLessonForm
+              moduleId={module.module_id}
+              onCreated={(lesson) => {
+                onLessonCreated(module.module_id, lesson);
+                setAddingLesson(false);
+              }}
+              onCancel={() => setAddingLesson(false)}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setAddingLesson(true)}
+              className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-ink-2 transition-colors hover:border-accent hover:text-accent-dark"
+            >
+              <PlusIcon className="h-3.5 w-3.5" />
+              Agregar lección
+            </button>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function CurriculumAccordion({
+  modules,
+  onLessonCreated,
+}: {
+  modules: AdminCurriculumModule[];
+  onLessonCreated: (moduleId: string, lesson: AdminCurriculumLesson) => void;
+}) {
+  if (modules.length === 0) {
+    return <p className="rounded-xl border border-border bg-surface p-6 text-center text-sm text-ink-3">Todavía no hay módulos — crea el primero arriba.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {modules.map((module) => (
+        <ModuleCard key={module.module_id} module={module} onLessonCreated={onLessonCreated} />
+      ))}
+    </div>
+  );
+}

--- a/app/app/(admin)/panel/components/icons.tsx
+++ b/app/app/(admin)/panel/components/icons.tsx
@@ -1,0 +1,31 @@
+export function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function PlusIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function UploadIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M12 3v12M7 8l5-5 5 5M5 21h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M5 13l4 4L19 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/app/app/(admin)/panel/components/markdown-editor.tsx
+++ b/app/app/(admin)/panel/components/markdown-editor.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRef } from "react";
+import ReactMarkdown from "react-markdown";
+import { UploadIcon } from "./icons";
+
+export function MarkdownEditor({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) {
+      return;
+    }
+
+    if (value.trim() && !window.confirm("Ya hay contenido en el editor. ¿Reemplazarlo con el archivo subido?")) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        onChange(reader.result);
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <label className="text-xs font-semibold text-ink-2">Contenido (markdown)</label>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-ink-2 transition-colors hover:border-accent hover:text-accent-dark"
+        >
+          <UploadIcon className="h-3.5 w-3.5" />
+          Subir archivo .md
+        </button>
+        <input ref={fileInputRef} type="file" accept=".md,.markdown,text/markdown" className="hidden" onChange={handleFileChange} />
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <textarea
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          rows={14}
+          placeholder="# Título de la lección&#10;&#10;Contenido en markdown..."
+          className="w-full resize-y rounded-lg border border-border bg-surface p-3 font-mono text-[12.5px] leading-relaxed text-ink outline-none focus:border-accent"
+        />
+        <div className="overflow-y-auto rounded-lg border border-border bg-surface-2 p-3 text-[13px] leading-relaxed text-ink-2 [&_a]:text-accent-dark [&_code]:font-mono [&_code]:text-[12px] [&_h1]:font-display [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-ink [&_h2]:font-display [&_h2]:text-[15px] [&_h2]:font-semibold [&_h2]:text-ink [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-ink [&_pre]:p-2 [&_pre]:text-white">
+          {value.trim() ? (
+            <ReactMarkdown>{value}</ReactMarkdown>
+          ) : (
+            <p className="text-ink-3 italic">La preview aparece acá mientras escribes.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/(admin)/panel/page.tsx
+++ b/app/app/(admin)/panel/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import { hasAdminGroup } from "@/lib/auth/admin";
+import { getFreshCognitoAccessToken } from "@/lib/auth/cognito-tokens";
+import { getSession } from "@/lib/auth/session";
+import { fetchCurriculum } from "@/lib/curriculum/api";
+import { AdminPanel } from "./components/admin-panel";
+
+export default async function AdminPanelPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/login");
+  }
+
+  // Chequeo de UX: la seguridad real la garantiza el authorizer JWT + el
+  // check de cognito:groups que hace curriculum-admin-write-prod en cada
+  // POST /admin/*. Esto solo evita mostrar la opción a quien no es admin.
+  const accessToken = await getFreshCognitoAccessToken();
+  if (!accessToken) {
+    redirect("/login");
+  }
+  if (!hasAdminGroup(accessToken)) {
+    redirect("/dashboard");
+  }
+
+  const result = await fetchCurriculum();
+
+  return (
+    <main className="min-h-screen bg-bg">
+      <div className="mx-auto max-w-[860px] px-8 py-10">
+        <p className="text-xs text-ink-3">Panel de administración</p>
+        <h1 className="mt-1 mb-6 font-display text-2xl font-semibold text-ink">Currículum</h1>
+
+        {result.ok ? (
+          <AdminPanel initialModules={result.modules} />
+        ) : (
+          <p className="rounded-xl border border-border bg-surface p-6 text-center text-sm text-ink-3">
+            No se pudo cargar el currículum. Intenta recargar la página.
+          </p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/app/api/admin/curriculum/lessons/route.ts
+++ b/app/app/api/admin/curriculum/lessons/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { createLesson } from "@/lib/curriculum/api";
+
+export async function POST(request: Request) {
+  let body: {
+    module_id?: unknown;
+    lesson_id?: unknown;
+    title?: unknown;
+    order?: unknown;
+    content_markdown?: unknown;
+    tags?: unknown;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (typeof body.module_id !== "string" || typeof body.lesson_id !== "string" || typeof body.title !== "string") {
+    return NextResponse.json({ error: "missing_fields" }, { status: 400 });
+  }
+
+  const tags = Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === "string") : undefined;
+
+  const result = await createLesson({
+    module_id: body.module_id,
+    lesson_id: body.lesson_id,
+    title: body.title,
+    order: typeof body.order === "number" ? body.order : undefined,
+    content_markdown: typeof body.content_markdown === "string" ? body.content_markdown : undefined,
+    tags,
+  });
+
+  if (!result.ok) {
+    const status = result.reason === "unauthenticated" ? 401 : result.reason === "forbidden" ? 403 : 502;
+    return NextResponse.json({ error: result.reason, message: result.message }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/app/api/admin/curriculum/modules/route.ts
+++ b/app/app/api/admin/curriculum/modules/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { createModule } from "@/lib/curriculum/api";
+
+export async function POST(request: Request) {
+  let body: { module_id?: unknown; title?: unknown; order?: unknown; level?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (typeof body.module_id !== "string" || typeof body.title !== "string") {
+    return NextResponse.json({ error: "missing_fields" }, { status: 400 });
+  }
+
+  const result = await createModule({
+    module_id: body.module_id,
+    title: body.title,
+    order: typeof body.order === "number" ? body.order : undefined,
+    level: typeof body.level === "number" ? body.level : undefined,
+  });
+
+  if (!result.ok) {
+    const status = result.reason === "unauthenticated" ? 401 : result.reason === "forbidden" ? 403 : 502;
+    return NextResponse.json({ error: result.reason, message: result.message }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/lib/auth/admin.ts
+++ b/app/lib/auth/admin.ts
@@ -1,0 +1,28 @@
+// El access_token usado acá viene siempre de getFreshCognitoAccessToken(),
+// pedido por este mismo servidor directo a Cognito por HTTPS en el mismo
+// request — no es un token que nos entregue un cliente sin confiar en él,
+// así que no hace falta verificar su firma para esta verificación. Es
+// además solo UX (ocultar/redirigir la opción de admin); la seguridad
+// real la garantiza el authorizer JWT + el check de cognito:groups que
+// hace la Lambda en cada POST /admin/*.
+const ADMIN_GROUP_REGEX = /\badmin\b/;
+
+function decodeAccessTokenPayload(accessToken: string): { "cognito:groups"?: string[] } | null {
+  const payloadB64 = accessToken.split(".")[1];
+  if (!payloadB64) {
+    return null;
+  }
+  try {
+    const padded = payloadB64.replace(/-/g, "+").replace(/_/g, "/");
+    const json = Buffer.from(padded, "base64").toString("utf-8");
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export function hasAdminGroup(accessToken: string): boolean {
+  const payload = decodeAccessTokenPayload(accessToken);
+  const groups = payload?.["cognito:groups"] ?? [];
+  return groups.some((group) => ADMIN_GROUP_REGEX.test(group));
+}

--- a/app/lib/curriculum/api.ts
+++ b/app/lib/curriculum/api.ts
@@ -1,0 +1,110 @@
+import { getFreshCognitoAccessToken } from "@/lib/auth/cognito-tokens";
+import { authEnv } from "@/lib/auth/env";
+
+export interface AdminCurriculumLesson {
+  lesson_id: string;
+  title: string;
+  order?: number;
+  tags?: string[];
+}
+
+export interface AdminCurriculumModule {
+  module_id: string;
+  title: string;
+  order?: number;
+  level?: number;
+  lessons: AdminCurriculumLesson[];
+}
+
+export type FetchCurriculumResult =
+  | { ok: true; modules: AdminCurriculumModule[] }
+  | { ok: false; reason: "api_error" };
+
+/**
+ * Llama a GET /curriculum (cloudsec-ninja-infra) — endpoint público, no
+ * necesita el mecanismo de refresh_token/access_token de Cognito.
+ */
+export async function fetchCurriculum(): Promise<FetchCurriculumResult> {
+  let response: Response;
+  try {
+    response = await fetch(`${authEnv.progressApiUrl}/curriculum`, { cache: "no-store" });
+  } catch (error) {
+    console.error("Error de red al llamar a GET /curriculum:", error);
+    return { ok: false, reason: "api_error" };
+  }
+
+  if (!response.ok) {
+    console.error(`GET /curriculum devolvió ${response.status}`);
+    return { ok: false, reason: "api_error" };
+  }
+
+  const data = (await response.json()) as { modules: AdminCurriculumModule[] };
+  return { ok: true, modules: data.modules };
+}
+
+export interface CreateModuleInput {
+  module_id: string;
+  title: string;
+  order?: number;
+  level?: number;
+}
+
+export interface CreateLessonInput {
+  module_id: string;
+  lesson_id: string;
+  title: string;
+  order?: number;
+  content_markdown?: string;
+  tags?: string[];
+}
+
+export type AdminWriteResult =
+  | { ok: true }
+  | { ok: false; reason: "unauthenticated" | "forbidden" | "api_error"; message?: string };
+
+/**
+ * POST genérico contra los endpoints /admin/curriculum/* (requieren rol
+ * admin — el authorizer JWT + la Lambda verifican cognito:groups, este
+ * cliente solo manda el access_token fresco, no duplica esa verificación).
+ */
+async function postAdminCurriculum(path: string, body: unknown): Promise<AdminWriteResult> {
+  const accessToken = await getFreshCognitoAccessToken();
+  if (!accessToken) {
+    return { ok: false, reason: "unauthenticated" };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${authEnv.progressApiUrl}${path}`, {
+      method: "POST",
+      headers: { Authorization: accessToken, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      cache: "no-store",
+    });
+  } catch (error) {
+    console.error(`Error de red al llamar a POST ${path}:`, error);
+    return { ok: false, reason: "api_error" };
+  }
+
+  if (response.status === 401) {
+    return { ok: false, reason: "unauthenticated" };
+  }
+  if (response.status === 403) {
+    return { ok: false, reason: "forbidden" };
+  }
+  if (!response.ok) {
+    const message = await response.text().catch(() => undefined);
+    console.error(`POST ${path} devolvió ${response.status}: ${message}`);
+    return { ok: false, reason: "api_error", message };
+  }
+
+  return { ok: true };
+}
+
+export function createModule(input: CreateModuleInput): Promise<AdminWriteResult> {
+  return postAdminCurriculum("/admin/curriculum/modules", input);
+}
+
+export function createLesson(input: CreateLessonInput): Promise<AdminWriteResult> {
+  return postAdminCurriculum("/admin/curriculum/lessons", input);
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,6 +13,7 @@
         "openid-client": "^6.8.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-markdown": "^10.1.0",
         "shiki": "^4.3.1"
       },
       "devDependencies": {
@@ -25,7 +26,7 @@
         "typescript": "^5.7.0"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=20"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1081,6 +1082,30 @@
         "tailwindcss": "4.3.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
@@ -1099,6 +1124,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.20.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
@@ -1113,7 +1144,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1140,6 +1170,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "license": "ISC"
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001800",
@@ -1171,6 +1211,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
@@ -1185,6 +1235,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1211,8 +1271,37 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -1260,6 +1349,22 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1290,6 +1395,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -1303,6 +1435,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -1311,6 +1453,68 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jiti": {
@@ -1593,6 +1797,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1601,6 +1815,104 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-to-hast": {
@@ -1624,6 +1936,216 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
@@ -1644,6 +2166,107 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
@@ -1659,6 +2282,60 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
@@ -1679,6 +2356,28 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-encode": "^2.0.0",
         "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
       }
     },
     "node_modules/micromark-util-symbol": {
@@ -1711,6 +2410,12 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1850,6 +2555,31 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1916,6 +2646,33 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -1939,6 +2696,39 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -2056,6 +2846,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2110,6 +2918,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2136,6 +2954,25 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "openid-client": "^6.8.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^10.1.0",
     "shiki": "^4.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Resumen

- Nueva ruta `/panel`: gate de admin server-side (Server Component) leyendo `cognito:groups` del access_token fresco con el mismo regex `\badmin\b` que usa la Lambda `curriculum-admin-write-prod`. Es solo UX (oculta la opción a quien no es admin) — la seguridad real la garantiza el authorizer JWT + el check que ya hace el backend en cada `POST /admin/*` (verificado end-to-end en S2-04a).
- Listado en acordeón (patrón visual de `/temario` del mockup) con `GET /curriculum` (público, sin refresh_token).
- Formulario "Crear módulo" → `POST /admin/curriculum/modules`.
- Formulario "Crear lección" (dentro de cada módulo) con editor markdown + preview en vivo vía `react-markdown`, e input de archivo `.md` que carga su contenido en el editor (con `confirm()` si ya había texto sin guardar) → `POST /admin/curriculum/lessons`.
- Ambos POST reusan el mecanismo de refresh_token/access_token fresco de S2-02/S2-03, vía dos route handlers proxy nuevos (`/api/admin/curriculum/modules`, `/api/admin/curriculum/lessons`) — mismo patrón que `/api/progress`.
- Crear módulo/lección actualiza la lista en memoria sin recargar la página; errores de red o 403 se muestran inline, nunca en silencio.

## Decisiones consultadas con el usuario

- **Librería de markdown**: `react-markdown` + textarea propio, sobre `@uiw/react-md-editor` — más liviano, control total de estilos con los tokens Tailwind ya definidos, mismo criterio minimalista que el resto del código de S2-03.
- **Contrato de `POST /admin/curriculum/lessons`**: confirmado por el usuario leyendo el código real de la Lambda — `{module_id, lesson_id, title, order?, content_markdown?, tags?}`. El de `/modules` (`{module_id, title, order?, level?}`) ya estaba verificado empíricamente desde S2-04a.

## Fuera de alcance (según la historia)

Editar/eliminar módulos o lecciones existentes, reordenar por drag-and-drop, validación de markdown más allá de "no vacío".

## Test plan

- [x] `tsc --noEmit` sin errores
- [x] `next build` verde (incluye lint embebido)
- [x] Smoke test local: `/panel` sin sesión redirige a `/login`
- [x] Smoke test local: `/panel` con sesión pero sin refresh_token redirige a `/login`
- [x] `GET /curriculum` real responde bien (usado por la página para el listado inicial)
- [ ] Prueba manual en navegador con usuario admin real — ver hand-off (no se pudo probar el camino feliz completo localmente porque el refresh_token anterior fue revocado deliberadamente en la sesión de S2-04a tras quedar expuesto en un chat de diagnóstico)

🤖 Generated with [Claude Code](https://claude.com/claude-code)