### PR TITLE
S2-04d: Acordeón de lecciones en el dashboard + revisitar completadas

### DIFF
--- a/app/app/(estudiante)/dashboard/components/icons.tsx
+++ b/app/app/(estudiante)/dashboard/components/icons.tsx
@@ -28,3 +28,11 @@ export function LockIcon({ className }: { className?: string }) {
     </svg>
   );
 }
+
+export function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/app/app/(estudiante)/dashboard/components/module-row.tsx
+++ b/app/app/(estudiante)/dashboard/components/module-row.tsx
@@ -1,5 +1,8 @@
-import type { ModuleView } from "@/lib/progress/view-model";
-import { CheckIcon, LockIcon } from "./icons";
+"use client";
+
+import { useState } from "react";
+import type { LessonView, ModuleView } from "@/lib/progress/view-model";
+import { CheckIcon, ChevronIcon, LockIcon } from "./icons";
 
 function StatusIcon({ status }: { status: ModuleView["status"] }) {
   if (status === "completed") {
@@ -52,7 +55,38 @@ function ModuleAction({ module }: { module: ModuleView }) {
   );
 }
 
+function LessonRow({ moduleId, lesson }: { moduleId: string; lesson: LessonView }) {
+  if (lesson.status === "locked") {
+    return (
+      <div className="flex cursor-not-allowed items-center gap-2.5 rounded-lg px-2.5 py-2 opacity-60">
+        <LockIcon className="h-3.5 w-3.5 shrink-0 text-ink-3" />
+        <span className="text-[13px] text-ink-3">{lesson.title}</span>
+      </div>
+    );
+  }
+
+  const isCompleted = lesson.status === "completed";
+  return (
+    <a
+      href={`/lecciones/${moduleId}/${lesson.id}`}
+      className={`flex items-center gap-2.5 rounded-lg px-2.5 py-2 transition-colors hover:bg-surface-2 ${
+        isCompleted ? "" : "bg-accent-soft"
+      }`}
+    >
+      {isCompleted ? (
+        <CheckIcon className="h-3.5 w-3.5 shrink-0 text-accent-dark" />
+      ) : (
+        <span className="h-2 w-2 shrink-0 rounded-full bg-accent" />
+      )}
+      <span className={`text-[13px] ${isCompleted ? "text-ink-2" : "font-semibold text-accent-dark"}`}>
+        {lesson.title}
+      </span>
+    </a>
+  );
+}
+
 export function ModuleRow({ module }: { module: ModuleView }) {
+  const [expanded, setExpanded] = useState(false);
   const isActive = module.status === "in_progress" || module.status === "not_started";
   const percent = module.totalLessons === 0 ? 0 : Math.round((module.completedLessons / module.totalLessons) * 100);
 
@@ -70,11 +104,31 @@ export function ModuleRow({ module }: { module: ModuleView }) {
             <p className="mt-0.5 text-[11.5px] text-ink-3">{metaText(module)}</p>
           </div>
         </div>
-        <ModuleAction module={module} />
+        <div className="flex items-center gap-3">
+          <ModuleAction module={module} />
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            aria-label={expanded ? "Ocultar lecciones" : "Ver lecciones"}
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-ink-3 transition-colors hover:bg-surface-2 hover:text-ink-2"
+          >
+            <ChevronIcon className={`h-4 w-4 transition-transform ${expanded ? "rotate-180" : ""}`} />
+          </button>
+        </div>
       </div>
       {isActive ? (
         <div className="mt-3 h-[5px] overflow-hidden rounded-full bg-surface-2">
           <div className="h-full rounded-full bg-accent transition-[width]" style={{ width: `${percent}%` }} />
+        </div>
+      ) : null}
+
+      {expanded ? (
+        <div className="mt-3 flex flex-col gap-0.5 border-t border-border pt-3">
+          {module.lessons.length > 0 ? (
+            module.lessons.map((lesson) => <LessonRow key={lesson.id} moduleId={module.id} lesson={lesson} />)
+          ) : (
+            <p className="px-2.5 py-2 text-[13px] text-ink-3 italic">Sin lecciones todavía.</p>
+          )}
         </div>
       ) : null}
     </div>

--- a/app/app/(estudiante)/lecciones/[moduleId]/[lessonId]/page.tsx
+++ b/app/app/(estudiante)/lecciones/[moduleId]/[lessonId]/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from "next/navigation";
 import { MarkdownContent } from "@/components/markdown-content";
 import { getSession } from "@/lib/auth/session";
 import { fetchCurriculum, fetchLesson } from "@/lib/curriculum/api";
+import { fetchProgress } from "@/lib/progress/api";
+import { CheckIcon } from "./components/icons";
 import { CompleteLessonButton } from "./components/complete-lesson-button";
 
 export default async function LessonPage({
@@ -18,8 +20,16 @@ export default async function LessonPage({
   }
 
   // GET /curriculum y GET /curriculum/{moduleId}/{lessonId} son públicos
-  // (no necesitan el refresh_token) y no dependen uno del otro.
-  const [lessonResult, curriculumResult] = await Promise.all([fetchLesson(moduleId, lessonId), fetchCurriculum()]);
+  // (no necesitan el refresh_token) y no dependen uno del otro. GET
+  // /progress sí lo necesita — si falla (token vencido, red, etc.) no
+  // bloqueamos el contenido público: se asume "no completada todavía" y
+  // se muestra el botón activo, cuyo propio manejo de error ya cubre un
+  // fallo real al hacer clic.
+  const [lessonResult, curriculumResult, progressResult] = await Promise.all([
+    fetchLesson(moduleId, lessonId),
+    fetchCurriculum(),
+    fetchProgress(),
+  ]);
 
   if (!lessonResult.ok) {
     return (
@@ -43,6 +53,11 @@ export default async function LessonPage({
 
   const lesson = lessonResult.lesson;
   const module = curriculumResult.ok ? curriculumResult.modules.find((m) => m.module_id === moduleId) : undefined;
+  const alreadyCompleted =
+    progressResult.ok &&
+    progressResult.items.some(
+      (item) => item.module_id === moduleId && item.lesson_id === lessonId && item.status === "completed",
+    );
 
   return (
     <main className="min-h-screen bg-bg">
@@ -76,7 +91,14 @@ export default async function LessonPage({
         <MarkdownContent markdown={lesson.content_markdown} />
 
         <div className="mt-8">
-          <CompleteLessonButton moduleId={moduleId} lessonId={lessonId} />
+          {alreadyCompleted ? (
+            <div className="flex w-fit items-center gap-2 rounded-lg bg-accent-soft px-5 py-3 text-sm font-semibold text-accent-dark">
+              <CheckIcon className="h-4 w-4" />
+              Ya completaste esta lección
+            </div>
+          ) : (
+            <CompleteLessonButton moduleId={moduleId} lessonId={lessonId} />
+          )}
         </div>
       </div>
     </main>

--- a/app/lib/progress/view-model.ts
+++ b/app/lib/progress/view-model.ts
@@ -2,6 +2,13 @@ import type { AdminCurriculumModule } from "@/lib/curriculum/api";
 import type { ProgressItem } from "./api";
 
 export type ModuleStatus = "completed" | "in_progress" | "locked" | "not_started";
+export type LessonStatus = "completed" | "available" | "locked";
+
+export interface LessonView {
+  id: string;
+  title: string;
+  status: LessonStatus;
+}
 
 export interface ModuleView {
   id: string;
@@ -11,6 +18,7 @@ export interface ModuleView {
   status: ModuleStatus;
   /** Lección a la que debe apuntar "Empezar"/"Continuar" — null si el módulo no tiene lecciones. */
   nextLessonId: string | null;
+  lessons: LessonView[];
 }
 
 export interface GoalView {
@@ -73,7 +81,29 @@ export function buildDashboardView(curriculumModules: AdminCurriculumModule[], i
 
     previousModulePassed = passesForUnlock;
 
-    const nextLesson = sortedLessons.find((lesson) => !completedLessonIds.has(lesson.lesson_id));
+    // Estado por lección: completada (por progreso real, sin importar su
+    // posición), la primera no completada en orden queda "available", y
+    // el resto de las no completadas después de esa quedan "locked". Si
+    // el módulo entero está locked, ninguna lección es accionable todavía
+    // aunque individualmente "sería" la disponible.
+    let availableAssigned = false;
+    const lessons: LessonView[] = sortedLessons.map((lesson) => {
+      const completedLesson = completedLessonIds.has(lesson.lesson_id);
+      let lessonStatus: LessonStatus;
+      if (status === "locked") {
+        lessonStatus = "locked";
+      } else if (completedLesson) {
+        lessonStatus = "completed";
+      } else if (!availableAssigned) {
+        availableAssigned = true;
+        lessonStatus = "available";
+      } else {
+        lessonStatus = "locked";
+      }
+      return { id: lesson.lesson_id, title: lesson.title, status: lessonStatus };
+    });
+
+    const nextLessonId = lessons.find((lesson) => lesson.status === "available")?.id ?? null;
 
     return {
       id: module.module_id,
@@ -81,7 +111,8 @@ export function buildDashboardView(curriculumModules: AdminCurriculumModule[], i
       totalLessons: totalModuleLessons,
       completedLessons,
       status,
-      nextLessonId: nextLesson?.lesson_id ?? null,
+      nextLessonId,
+      lessons,
     };
   });
 


### PR DESCRIPTION
## Resumen

- Cada card de módulo en `/dashboard` se vuelve expandible: un botón de chevron (separado del CTA "Empezar"/"Continuar" para no anidar elementos interactivos) muestra/oculta la lista de lecciones del módulo.
- Estado por lección, cruzando `GET /curriculum` con `GET /progress`:
  - **Completada**: check verde, clickeable, lleva a la lección (aunque esté fuera de orden — completar una lección "adelantada" no la vuelve inaccesible).
  - **Disponible**: la primera no completada en orden, resaltada (fondo `accent-soft`, texto en negrita), clickeable.
  - **Bloqueada**: el resto de las no completadas después de la disponible — ícono de candado, no clickeable.
  - Si el módulo entero está `locked` (el anterior no está completo), todas sus lecciones se fuerzan a `locked` aunque individualmente alguna "sería" la disponible.
- La página de lección ahora también llama `GET /progress` para saber si el usuario ya completó esa lección puntual — si sí, reemplaza el botón "Completar lección" por un indicador "✓ Ya completaste esta lección", sin volver a llamar `POST /progress`.

## Decisión de diseño (dentro del margen que dejó la historia)

El acordeón de `/panel` (S2-04b) no tiene noción de completado/bloqueado por lección — es una lista plana para el admin. No había un componente real que reusar tal cual sin forzarlo a hacer algo para lo que no fue diseñado, así que reutilicé la **interacción** (toggle + chevron rotando, mismo patrón visual) pero construí la lógica de estados de lección desde cero, que es lo genuinamente nuevo de esta historia.

## Resiliencia

Si `GET /progress` falla al cargar la página de lección (token vencido, red), no se bloquea el contenido público — se asume "no completada todavía" y se muestra el botón activo de siempre. Si el usuario hace clic y de verdad falla, el manejo de error visible que ya existía (S2-03) lo cubre.

## Fuera de alcance (según la historia, punto 4)

No hay bloqueo server-side para acceso directo por URL a una lección bloqueada — solo bloqueo visual en el dashboard, decisión explícita de la historia.

## Test plan

- [x] `tsc --noEmit` sin errores
- [x] `next build` verde (incluye lint embebido)
- [x] Smoke test: lección real con `GET /progress` fallando (sin refresh_token) sigue mostrando el botón activo sin crashear, `alreadyCompleted` correctamente `false`
- [x] Smoke test: `/dashboard` con sesión pero sin refresh_token sigue redirigiendo a `/login` (sin cambios de comportamiento)
- [ ] Prueba manual en navegador con usuario real y progreso real — ver hand-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)