### PR TITLE
S3-01: Vista pública de temario, sin login, con currículum real

### DIFF
--- a/app/app/(public)/temario/components/api-error-notice.tsx
+++ b/app/app/(public)/temario/components/api-error-notice.tsx
@@ -1,0 +1,7 @@
+export function ApiErrorNotice() {
+  return (
+    <div className="mt-8 rounded-xl border border-border bg-surface-2 px-6 py-8 text-center">
+      <p className="text-sm text-ink-2">No pudimos cargar el temario en este momento. Intenta recargar la página en unos segundos.</p>
+    </div>
+  );
+}

--- a/app/app/(public)/temario/components/empty-curriculum-notice.tsx
+++ b/app/app/(public)/temario/components/empty-curriculum-notice.tsx
@@ -1,0 +1,7 @@
+export function EmptyCurriculumNotice() {
+  return (
+    <div className="mt-8 rounded-xl border border-border bg-surface-2 px-6 py-8 text-center">
+      <p className="text-sm text-ink-2">Todavía no hay ningún módulo publicado en el currículum. Vuelve pronto.</p>
+    </div>
+  );
+}

--- a/app/app/(public)/temario/components/icons.tsx
+++ b/app/app/(public)/temario/components/icons.tsx
@@ -1,0 +1,16 @@
+export function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+      <path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/app/app/(public)/temario/components/temario-explorer.tsx
+++ b/app/app/(public)/temario/components/temario-explorer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { AdminCurriculumLesson, AdminCurriculumModule } from "@/lib/curriculum/api";
+import { ChevronIcon, SearchIcon } from "./icons";
+
+function normalize(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+function sortByOrder<T extends { order?: number | null }>(items: T[]): T[] {
+  return [...items].sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity));
+}
+
+function ModuleCard({ module, query }: { module: AdminCurriculumModule; query: string }) {
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+
+  const q = normalize(query);
+  const lessons = useMemo(() => sortByOrder(module.lessons), [module.lessons]);
+  const titleMatch = q !== "" && normalize(module.title).includes(q);
+  const matchingLessonIds = useMemo(() => {
+    if (q === "") return new Set<string>();
+    return new Set(lessons.filter((lesson) => normalize(lesson.title).includes(q)).map((lesson) => lesson.lesson_id));
+  }, [lessons, q]);
+
+  // Cuando la búsqueda solo pega en lecciones (no en el título del módulo),
+  // el módulo se abre automáticamente para que se vean los resultados —
+  // mismo comportamiento validado en design-reference/mockup.html.
+  const searchOpensThis = q !== "" && !titleMatch && matchingLessonIds.size > 0;
+  const open = manualOpen ?? searchOpensThis;
+
+  return (
+    <div className={`rounded-xl border bg-surface transition-colors ${open ? "border-accent" : "border-border"}`}>
+      <button
+        type="button"
+        onClick={() => setManualOpen(!open)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left"
+      >
+        <div>
+          <p className="text-sm font-semibold text-ink">
+            {module.order ?? "·"}. {module.title}
+          </p>
+          <p className="mt-0.5 text-[12.5px] text-ink-3">
+            {lessons.length} lecciones{module.level ? ` · nivel ${module.level}` : ""}
+          </p>
+        </div>
+        <ChevronIcon className={`h-4.5 w-4.5 shrink-0 text-ink-3 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open ? (
+        <div className="border-t border-border px-5 pb-4 pt-3">
+          {lessons.length > 0 ? (
+            <ul className="flex flex-col gap-0.5">
+              {lessons.map((lesson: AdminCurriculumLesson) => {
+                const isHit = matchingLessonIds.has(lesson.lesson_id);
+                return (
+                  <li
+                    key={lesson.lesson_id}
+                    className={`flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-[13px] ${
+                      isHit ? "font-semibold text-ember-dark" : "text-ink-2"
+                    }`}
+                  >
+                    <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${isHit ? "bg-ember" : "bg-accent"}`} />
+                    {lesson.title}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p className="px-2.5 py-2 text-[13px] italic text-ink-3">Este módulo todavía no tiene lecciones.</p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function TemarioExplorer({ modules }: { modules: AdminCurriculumModule[] }) {
+  const [query, setQuery] = useState("");
+  const q = normalize(query);
+  const sortedModules = useMemo(() => sortByOrder(modules), [modules]);
+
+  const visibleModules = useMemo(() => {
+    if (q === "") return sortedModules;
+    return sortedModules.filter((module) => {
+      const titleMatch = normalize(module.title).includes(q);
+      const hasLessonMatch = module.lessons.some((lesson) => normalize(lesson.title).includes(q));
+      return titleMatch || hasLessonMatch;
+    });
+  }, [sortedModules, q]);
+
+  return (
+    <div className="mt-8">
+      <div className="flex items-center gap-2.5 rounded-xl border border-border bg-surface px-4 py-3">
+        <SearchIcon className="h-4 w-4 shrink-0 text-ink-3" />
+        <input
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Busca por tema, ej. IAM, cifrado, compliance..."
+          aria-label="Buscar en el temario"
+          className="w-full border-none bg-transparent text-sm text-ink outline-none placeholder:text-ink-3"
+        />
+      </div>
+
+      {visibleModules.length === 0 ? (
+        <p className="py-6 text-center text-[13.5px] text-ink-3">No encontramos lecciones para esa búsqueda.</p>
+      ) : (
+        <div className="mt-6 flex flex-col gap-3">
+          {visibleModules.map((module) => (
+            <ModuleCard key={module.module_id} module={module} query={query} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/app/(public)/temario/page.tsx
+++ b/app/app/(public)/temario/page.tsx
@@ -1,0 +1,43 @@
+import { getSession } from "@/lib/auth/session";
+import { fetchCurriculum } from "@/lib/curriculum/api";
+import { ApiErrorNotice } from "./components/api-error-notice";
+import { EmptyCurriculumNotice } from "./components/empty-curriculum-notice";
+import { TemarioExplorer } from "./components/temario-explorer";
+
+export default async function TemarioPage() {
+  // /temario es pública: no hay redirect si no hay sesión. getSession()
+  // solo se usa para decidir a dónde manda el CTA final.
+  const [session, result] = await Promise.all([getSession(), fetchCurriculum()]);
+  const ctaHref = session ? "/dashboard" : "/login";
+
+  return (
+    <main className="min-h-screen bg-bg">
+      <div className="mx-auto max-w-[820px] px-8 py-14">
+        <div className="text-center">
+          <p className="text-xs font-semibold uppercase tracking-wide text-accent-dark">Explora antes de empezar</p>
+          <h1 className="mt-2 font-display text-[26px] font-semibold text-ink">Temario completo</h1>
+          <p className="mt-2 text-sm text-ink-2">
+            Público, sin necesidad de cuenta. Crea la tuya cuando quieras guardar tu progreso.
+          </p>
+        </div>
+
+        {!result.ok ? (
+          <ApiErrorNotice />
+        ) : result.modules.length === 0 ? (
+          <EmptyCurriculumNotice />
+        ) : (
+          <TemarioExplorer modules={result.modules} />
+        )}
+
+        <div className="mt-10 text-center">
+          <a
+            href={ctaHref}
+            className="inline-block rounded-full bg-accent px-8 py-3 text-sm font-semibold text-[#04231a] transition-colors hover:bg-accent-hover"
+          >
+            Empezar mi ruta
+          </a>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Resumen
- Nueva ruta pública `app/(public)/temario/page.tsx`: trae `GET /curriculum` (público, sin auth) y muestra los módulos/lecciones reales con el mismo patrón de acordeón que ya existe en `/panel` y en el dashboard del estudiante (adaptado, sin datos de progreso porque la vista es pública).
- Buscador client-side sobre los datos ya cargados: filtra por coincidencia de texto en el título de módulo o de lección. Si una lección matchea pero el título del módulo no, el módulo se auto-expande y la lección resaltada se distingue en color ámbar — mismo comportamiento validado en `design-reference/mockup.html`. Si no hay resultados, muestra el mensaje "No encontramos lecciones para esa búsqueda." en vez de una lista vacía.
- CTA persistente "Empezar mi ruta": sin sesión manda a `/login` (Hosted UI de Cognito, mismo mecanismo que la landing); con sesión activa manda directo a `/dashboard`.
- Maneja currículum vacío y error de API con mensajes propios (no reutiliza el copy del dashboard porque ahí menciona "tu progreso", que no aplica en una vista pública sin sesión).
- Sin ningún guard de sesión — la página es un server component que nunca redirige por falta de cookie; `getSession()` solo se usa para decidir el `href` del CTA.

## Nota sobre la rama base
Al arrancar esta historia noté que el PR #139 (S2-04d, acordeón del dashboard) seguía abierto sin mergear, y esta historia depende de reusar ese patrón de acordeón. Se confirmó con el autor que ya estaba validado funcionando, así que se mergeó primero a `development` (merge commit, consistente con el resto del historial) y esta rama se creó desde ahí.

## Test plan
- [x] `npm run build` — compila sin errores, `/temario` queda marcada como ruta dinámica (ƒ), igual que `/dashboard` y `/panel`.
- [x] Verificado en navegador (Playwright headless) sin cookies de sesión: la página carga sin redirigir a `/login`, muestra los módulos reales del currículum de prueba, el acordeón expande/colapsa, la búsqueda resalta la lección que matchea y auto-expande su módulo, la búsqueda sin resultados muestra el mensaje correcto, y el CTA apunta a `/login`.
- [x] Verificado en navegador con una cookie de sesión válida simulada: el CTA apunta a `/dashboard`.
- [x] Sin errores de consola del navegador en ningún escenario.
- No hay framework de tests automatizados configurado en el repo todavía (no `jest`/`vitest`, sin `scripts.test`) — igual que en las historias anteriores de este proyecto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)